### PR TITLE
Fix text overlap issue

### DIFF
--- a/components/_/navigation.jsx
+++ b/components/_/navigation.jsx
@@ -19,7 +19,8 @@ export default function Navigation() {
       {/* Container */}
       <div
         id="menu-navigation"
-        className="hidden top-0 bg-primary-2 w-full h-screen sm:w-1/2 sm:border-2 sm:border-white sm:right-0">
+        className="hidden top-0 bg-primary-2 w-full h-screen sm:w-1/2 sm:border-2 sm:border-white sm:right-0"
+        style={{zIndex: 9}}>
         <span className="block text-secondary-1 mt-2 ml-4 text-3xl mb-8">Navigation</span>
         <ul className="block text-secondary-1 text-sm w-full">
           <li className="w-full block">


### PR DESCRIPTION
Previously, a visual glitch was observed when viewing the membership page while
the main navigation menu was open - the text on the membership page seemed to
overlap into the main navigation panel.

The exact cause and location of the error was not yet determined, but a change
which appears to fix the issue is to add a zIndex style to the navigation menu.

I was not sure where to put the new style - happy to move it if inline is less desirable.

Before the change:
![image](https://user-images.githubusercontent.com/10395940/107200320-88257f80-6a32-11eb-9449-aa6841cacce7.png)

After the change:
![image](https://user-images.githubusercontent.com/10395940/107200527-c6bb3a00-6a32-11eb-8a9a-7edf8e5a574d.png)
