### PR TITLE
Include Code of Conduct on the main site

### DIFF
--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -2,7 +2,7 @@
 title: 'Code of Conduct'
 date: '2021-11-04T15:53:29Z'
 author: 'Artifactory Management Committee'
-heroUrl: 'https://via.placeholder.com/300x150'
+heroUrl: ''
 ---
 
 # Code Of Conduct

--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -39,9 +39,9 @@ Report any conflicts of interest.
 All attendees are encouraged to proactively report issues as soon as they arise. Reporting of issues in the early stage can help prevent escalation to larger problems. Sometimes an attendee may be unaware of the impact of their actions and so reporting helps correct those behaviours and benefits the community.
 
 Reporting methods:
-* Talk to a committee member	(see: https://wiki.artifactory.org.au/doku.php?id=committee:start#committee_members)
-* Email the management committee: committee@artifactory.org.au 
-* Email the executive committee (Chair, Deputy Chair, Secretary Treasurer): exec@artifactory.org.au 
+* Talk to a [committee member](https://wiki.artifactory.org.au/doku.php?id=committee:start#committee_members)
+* [Email](mailto:committee@artifactory.org.au) the management committee
+* [Email](exec@artifactory.org.au) the executive committee (Chair, Deputy Chair, Secretary Treasurer)
 * Slack direct message to a committee member
 * Ask another Artifactory member to report the incident on your behalf
 
@@ -57,5 +57,5 @@ All incidents are handled on a case-by-case basis. Depending on the incident, th
 
 ## References
 Guided by some other excellent code of conduct documents:
-* HSBNE: https://hsbne.org/admin/code
-* LinuxConfAu: https://lca2022.linux.org.au/attend/code-of-conduct/
+* [HSBNE](https://hsbne.org/admin/code)
+* [LinuxConfAu](https://lca2022.linux.org.au/attend/code-of-conduct/)

--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -2,6 +2,7 @@
 title: Code of Conduct
 date: 2021-11-04T15:53:29Z
 author: Artifactory Management Committee
+heroUrl: https://via.placeholder.com/300x150
 ---
 
 # Code Of Conduct

--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -1,0 +1,60 @@
+---
+title: Code of Conduct
+date: 2021-11-04T15:53:29Z
+author: Artifactory Management Committee
+---
+
+# Code Of Conduct
+We must all work to foster a collaborative, inclusive, safe and creative environment for all attendees: members and visitors alike. This code of conduct gives guidance on what is expected at the Artifactory premises, at Artifactory events, on Slack and other Artifactory online communication platforms.
+
+## Respectful Behaviour
+*Treat one another with respect*
+
+The Artifactory attendees come from a diverse variety of backgrounds. That diversity enriches our community and so we must work to ensure all members feel welcome and safe. Sexual harassment, bullying or discrimination will not be tolerated - both in person and online. Any behaviours that make attendees feel uncomfortable or unsafe are unacceptable and action will be taken to ensure a safe environment for all attendees.
+
+Sometimes disagreements can be frustrating but that is no excuse for poor behavior or poor manners. Disagreement, debate and constructive criticism can help develop ideas but it should never cross into personal attacks. 
+
+Many Artifactory attendees offer training, help and advice to members and visitors. We should be mindful that these people are volunteers and so must be treated with respect and allowed time to work on their own projects if they so wish.
+
+Our workshop is a shared space with an abundance of communal work areas and tools. Leave the space clean and tidy for other attendees so that volunteers don’t have to spend time cleaning up after you.
+
+## Safe Use of Tools
+*The safety of every member is very important*
+
+Always follow established procedures, adhere to safety signage and wear appropriate protective equipment. Ask for help and training if you are unsure how to use our tools and follow that advice. Consider the risk to others around you and put up barriers, exclusion zones or signage as needed.
+
+Do not use tools while under the influence of alcohol, drugs, or other inhibiting substances.
+
+## Integrity
+*Always be honest*
+
+Report any damage to tools including mistakes you make. It happens, we have all been there! If you come across damaged tools or low consumables, likewise report it. 
+
+Respect the ownership of tools and materials. Do not remove Artifactory equipment from the premises unless you have permission. Ensure you have permission before using another member’s tools or materials.
+
+Report any conflicts of interest.
+
+## Complaints and Reporting
+All attendees are encouraged to proactively report issues as soon as they arise. Reporting of issues in the early stage can help prevent escalation to larger problems. Sometimes an attendee may be unaware of the impact of their actions and so reporting helps correct those behaviours and benefits the community.
+
+Reporting methods:
+* Talk to a committee member	(see: https://wiki.artifactory.org.au/doku.php?id=committee:start#committee_members)
+* Email the management committee: committee@artifactory.org.au 
+* Email the executive committee (Chair, Deputy Chair, Secretary Treasurer): exec@artifactory.org.au 
+* Slack direct message to a committee member
+* Ask another Artifactory member to report the incident on your behalf
+
+The Perth Artifactory has processes in place to ensure confidentiality of reported incidents.
+
+All incidents are handled on a case-by-case basis. Depending on the incident, the response may include:
+* Talking with the involved people, explaining the issues and building better understanding between attendees
+* Written formal warning for the specific incident
+* Temporary suspension of membership including restricted access to the premises and online platforms (part 4 of constitution)
+* Termination of membership (part 4 of constitution)
+* Barring from the Artifactory premises and online platforms
+* Reporting to any relevant authorities
+
+## References
+Guided by some other excellent code of conduct documents:
+* HSBNE: https://hsbne.org/admin/code
+* LinuxConfAu: https://lca2022.linux.org.au/attend/code-of-conduct/

--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -1,8 +1,8 @@
 ---
-title: Code of Conduct
-date: 2021-11-04T15:53:29Z
-author: Artifactory Management Committee
-heroUrl: https://via.placeholder.com/300x150
+title: 'Code of Conduct'
+date: '2021-11-04T15:53:29Z'
+author: 'Artifactory Management Committee'
+heroUrl: 'https://via.placeholder.com/300x150'
 ---
 
 # Code Of Conduct

--- a/components/_/footer.jsx
+++ b/components/_/footer.jsx
@@ -39,6 +39,11 @@ export default function Footer() {
                 <a>Webcams</a>
               </Link>
             </li>
+            <li>
+              <Link href="/pages/code_of_conduct">
+                <a>Code of Conduct</a>
+              </Link>
+            </li>
           </ul>
         </div>
         {/* More Info Container */}


### PR DESCRIPTION
Potential visitors shouldn't have to go to the wiki to view the code of conduct.