### PR TITLE
Update links after wiki migration

### DIFF
--- a/_pages/code_of_conduct.md
+++ b/_pages/code_of_conduct.md
@@ -39,7 +39,7 @@ Report any conflicts of interest.
 All attendees are encouraged to proactively report issues as soon as they arise. Reporting of issues in the early stage can help prevent escalation to larger problems. Sometimes an attendee may be unaware of the impact of their actions and so reporting helps correct those behaviours and benefits the community.
 
 Reporting methods:
-* Talk to a [committee member](https://wiki.artifactory.org.au/doku.php?id=committee:start#committee_members)
+* Talk to a [committee member](https://wiki.artifactory.org.au/en/docs/committee/home)
 * [Email](mailto:committee@artifactory.org.au) the management committee
 * [Email](mailto:exec@artifactory.org.au) the executive committee (Chair, Deputy Chair, Secretary Treasurer)
 * Slack direct message to a committee member

--- a/_pages/membership.md
+++ b/_pages/membership.md
@@ -19,7 +19,7 @@ Full: [$75/mo](https://artifactory.tidyhq.com/public/membership_levels/57b90dbb3
 Concession: [$45/mo](https://artifactory.tidyhq.com/public/membership_levels/53401b970f)
 
 - Access to a communal workshop space located in an industrial estate, with indoor and outdoor work areas (excluding rehearsal room)
-- Access to heavy duty tools, machines and facilities (some tools incur [additional costs](https://wiki.artifactory.org.au/doku.php?id=committee:committeerulings#tool_usage_fees))
+- Access to heavy duty tools, machines and facilities (some tools incur [additional costs](https://wiki.artifactory.org.au/en/docs/policies/fees))
 - Discounts or free entry for Artifactory run events and workshops
 - Free WIFI, small kitchenette and toilet facilities
 - Eligible for a 24/7 key (A bond equal to three months membership is required)
@@ -39,6 +39,6 @@ Our full/concession membership can be purchased as a gift [here](https://artifac
 
 ## Who can be a member?
 
-Any person who is at least 18 years of age and supports the objects of the Association is eligible to apply to become a member. For further information see our [Constitution](https://wiki.artifactory.org.au/constitution).
+Any person who is at least 18 years of age and supports the objects of the Association is eligible to apply to become a member. For further information see our [Constitution](https://wiki.artifactory.org.au/en/constitution).
 
-Members’ minors are welcome to use the Artifactory but must remain under parental/guardian supervision. The exact wording on this policy can be found [here](https://wiki.artifactory.org.au/doku.php?id=committee:committeerulings#minors_in_the_space).
+Members’ minors are welcome to use the Artifactory but must remain under parental/guardian supervision. The exact wording on this policy can be found [here](https://wiki.artifactory.org.au/en/docs/policies/bylaws).

--- a/components/_/footer.jsx
+++ b/components/_/footer.jsx
@@ -30,7 +30,7 @@ export default function Footer() {
               </Link>
             </li>
             <li>
-              <Link href="https://wiki.artifactory.org.au/doku.php">
+              <Link href="https://wiki.artifactory.org.au/">
                 <a>Wiki</a>
               </Link>
             </li>

--- a/components/_/navigation.jsx
+++ b/components/_/navigation.jsx
@@ -39,7 +39,7 @@ export default function Navigation() {
           <hr />
           <li className="w-full block">
             <a
-              href="https://wiki.artifactory.org.au/doku.php"
+              href="https://wiki.artifactory.org.au/"
               className="block px-4 py-2 w-full hover:bg-primary-1 hover:text-highlight-1">
               Wiki
             </a>


### PR DESCRIPTION
[The wiki.js](https://github.com/perth-artifactory/wiki) instance is now live on wiki.artifactory.org.au and some links need to be updated.